### PR TITLE
Fixed the black borders at top

### DIFF
--- a/css/gatewaypage.css
+++ b/css/gatewaypage.css
@@ -1,5 +1,5 @@
 html, body {
-	border-top: 5px solid #000;
+	/*border-top: 5px solid #000;*/
 	color: #333;
 	padding: 0 0 40px;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
The gaewaypage.css was applying a weird/unnecessary black top border to html,body. Removed by commenting out in this rev of the page mockup.
