### PR TITLE
Footer links now at https versions and some have moved altogether

### DIFF
--- a/p/branching.html
+++ b/p/branching.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1>Branching and Merging</h1>
       <p>Create and work on topic and long running branches, merge between them and delete them.</p>
     </div>
-    
+
     <div class="content">
       <div class="span-21"><hr/><p>As we touched on in the first lesson, the way that Git handles branching and merging is pretty unique. First of all, it&#8217;s incredibly fast, both to create new branches and to switch between them. Git has a single working directory that it replaces with the contents of the branch you&#8217;re working on, so you don&#8217;t have to have separate directories for each branch.</p>
 
@@ -51,9 +51,9 @@
 <pre><code>$ git branch
 * master</code></pre>
 
-<p>We can see that we only have one branch &#8216;master&#8217; and the &#8217;*&#8217; indicates that we are currently on it. For the purposes of illustrating this, I will show the commit history model. Here, the green boxes are each commit and the arrows are where each commit points to for its parent or parents. This is basically how Git actually stores it&#8217;s commit data.</p>
+<p>We can see that we only have one branch &#8216;master&#8217; and the &#8217;*&#8217; indicates that we are currently on it. For the purposes of illustrating this, I will show the commit history model. Here, the green boxes are each commit and the arrows are where each commit points to for its parent or parents. This is basically how Git actually stores its commit data.</p>
 
-<p><img src='../images/branch/step1.png' alt='Branch Step 1' /></p>
+<p><img alt='Branch Step 1' src='../images/branch/step1.png' /></p>
 
 <p>You can see, in Git, branches are simply lightweight pointers to a particular commit. The history is simply figured out by traversing the parents, one commit at a time.</p>
 
@@ -63,7 +63,7 @@
 
 <pre><code>$ git branch experiment</code></pre>
 
-<p><img src='../images/branch/step2.png' alt='Branch Step 2' /></p>
+<p><img alt='Branch Step 2' src='../images/branch/step2.png' /></p>
 
 <p>To switch to that branch so that the work we do is saved to it instead of the &#8216;master&#8217; branch, we run the &#8216;git checkout&#8217; command&#8217;</p>
 
@@ -77,7 +77,7 @@ $ git branch
 
 <h3 id='working_in_multiple_branches'>working in multiple branches</h3>
 
-<p>So, lets add a TODO file, make a change to the &#8216;simplegit.rb&#8217; file, and then make a commit with both changes in it.</p>
+<p>So, let&#8217;s add a TODO file, make a change to the &#8216;simplegit.rb&#8217; file, and then make a commit with both changes in it.</p>
 
 <pre><code>$ vim lib/simplegit.rb
 $ vim TODO
@@ -87,7 +87,7 @@ $ git commit -am &#39;added a todo and added simplegit functions&#39;
  2 files changed, 10 insertions(+), 0 deletions(-)
  create mode 100644 TODO</code></pre>
 
-<p><img src='../images/branch/step3.png' alt='Branch Step 3' /></p>
+<p><img alt='Branch Step 3' src='../images/branch/step3.png' /></p>
 
 <p>Now if we take a look, we can see that we have 3 files and one subdirectory.</p>
 
@@ -112,7 +112,7 @@ Switched to branch &quot;experiment&quot;
 $ ls
 README		Rakefile	TODO		lib</code></pre>
 
-<p><img src='../images/branch/step4.png' alt='Branch Step 4' /></p>
+<p><img alt='Branch Step 4' src='../images/branch/step4.png' /></p>
 
 <p>We could even go back to the master branch and create a new branch and start committing there. Most Git developers will have several branches running at the same time, each with a specific theme or focus - a new feature or bug fix that lasts hours or even minutes, or longer running branches for large scale refactorings that periodically merge in changes from mainline branches.</p>
 
@@ -136,7 +136,7 @@ Merge made by recursive.
 
 <p>Easy peasy - you&#8217;re merged.</p>
 
-<p><img src='../images/branch/step5.png' alt='Branch Step 5' /></p>
+<p><img alt='Branch Step 5' src='../images/branch/step5.png' /></p>
 
 <h3 id='merge_conflict_resolution'>merge conflict resolution</h3>
 
@@ -170,9 +170,9 @@ $ git commit
 
 <p>For example, let&#8217;s say we switched back to the &#8216;experiment&#8217; branch, made a few changes, then at some point merged it back into &#8216;master&#8217; again, making our history look something like this.</p>
 
-<p><img src='../images/branch/step6.png' alt='Branch Step 6' /></p>
+<p><img alt='Branch Step 6' src='../images/branch/step6.png' /></p>
 
-<p>Since Git does it&#8217;s merges as a simple 3 way merge based on the commit history snapshots, doing multiple merges is often very easy. It will only have to merge in changes introduced on both branches since the last merge - it will not have to re-merge anything.</p>
+<p>Since Git does its merges as a simple 3 way merge based on the commit history snapshots, doing multiple merges is often very easy. It will only have to merge in changes introduced on both branches since the last merge - it will not have to re-merge anything.</p>
 
 <p>When you are done with a branch, say in this case the &#8216;experiment&#8217; branch, we can simply delete it with &#8216;git branch -d&#8217;</p>
 
@@ -188,16 +188,15 @@ $ git commit
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/p/intro.html
+++ b/p/intro.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1>Introduction To Git</h1>
       <p>What Git is, why you would want to use it and where to get it and learn about it.</p>
     </div>
-    
+
     <div class="content">
       <div class="span-21"><center><embed src="http://blip.tv/play/Aeu2CAA" type="application/x-shockwave-flash" width="790" height="430" allowscriptaccess="always" allowfullscreen="true"></embed></center><hr/><p>Welcome to the first lesson of the GitHub Learning course. This course will lead you through a series of lessons that will demonstrate how to use Git quickly and easily - many of the lessons will have screencasts that you can watch as well, if you learn better that way.</p>
 
@@ -68,13 +68,13 @@ $ git help log</code></pre>
 
 <p>Git is an open source project, that has been active for several years and is written mostly in C.</p>
 
-<p><img src='../images/git-lang.png' alt='Git Language Breakdown' /></p>
+<p><img alt='Git Language Breakdown' src='../images/git-lang.png' /></p>
 
 <p>At any time you can get the full source code to analyze or improve upon. To get a download of the source code, visit <a href='http://git-scm.com/download'>git-scm.com/download</a>. Git is licensed under the GNU General Public License.</p>
 
 <h3 id='offline_and_fast'>offline and fast</h3>
 
-<p>Git is fully distributed, which means that it can work almost entirely offline. In stark contrast to VCS tools like Perforce or Subversion, Git does nearly all of it&#8217;s operations without needing a network connection, including history viewing, difference viewing and commiting.</p>
+<p>Git is fully distributed, which means that it can work almost entirely offline. In stark contrast to VCS tools like Perforce or Subversion, Git does nearly all of its operations without needing a network connection, including history viewing, difference viewing and commiting.</p>
 
 <p>This also means that Git is very fast compared to those systems partially due to the fact that none of these operations has any dependency on network latency. For example, take a look at how fast the simple &#8216;log&#8217; command takes to run in Git and in Subversion.</p>
 
@@ -130,7 +130,7 @@ sys	0m0.011s</code></pre>
 
 <p>Commits, then, are simply objects that contain some metadata about the commit (the message, author, date, etc), a pointer to a single snapshot of the project and pointers to the commit(s) that came directly before it. Git&#8217;s commit history and data model is really just a directed graph - a simple series of snapshots.</p>
 
-<p><img src='../images/snapshots.png' alt='Git Data Model' /></p>
+<p><img alt='Git Data Model' src='../images/snapshots.png' /></p>
 
 <p>Keeping this in mind is helpful when you&#8217;re thinking about what Git will do in a given situation.</p>
 
@@ -156,16 +156,15 @@ sys	0m0.011s</code></pre>
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/p/log.html
+++ b/p/log.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1>Git History</h1>
       <p>Browse your project history, find specific commits and visualize the branching and merging actions.</p>
     </div>
-    
+
     <div class="content">
       <div class="span-21"><hr/><p>One of the most commonly used commands is the &#8216;git log&#8217; command. This command shows you the commit history of your project, so you can see what has happened up to this point. With no options, it will start from the last commit on the branch you&#8217;re currently on and show you all the commits that are ancestors of that in reverse chronological order.</p>
 
@@ -386,16 +386,15 @@ cf9957875c3a27b6ae4593e1fa9d4dabbde68433 completion: Fix GIT_PS1_SHOWDIRTYSTA
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/p/normal.html
+++ b/p/normal.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1>Normal Workflow</h1>
       <p>Syncronize with a remote repository, make changes, then stage and commit them.</p>
     </div>
-    
+
     <div class="content">
       <div class="span-21"><hr/><p>So you have a Git repository and everything is all setup. What now?</p>
 
@@ -121,7 +121,7 @@ no changes added to commit (use &quot;git add&quot; and/or &quot;git commit -a&q
 
 <p>We can see that we have two files in the &#8216;Changed but not updated&#8217; section, which means that they are <strong>unstaged</strong>. That is, if we commit right now, nothing will happen. You have to <strong>stage</strong> a file before you can commit it.</p>
 
-<p><img src='../images/staging.png' alt='Git Staging Workflow' /></p>
+<p><img alt='Git Staging Workflow' src='../images/staging.png' /></p>
 
 <p>So, let&#8217;s stage the files. Git uses the &#8216;git add&#8217; command both to begin tracking files and also to stage changes to them. So let&#8217;s stage the changes in just the README file, then take a look at our status again.</p>
 
@@ -234,7 +234,7 @@ index c526f88..879f0d4 100644
 
 <p>This is a very useful command, because it tells you what changes you&#8217;re introducing were you to run &#8216;git commit&#8217; (without the &#8216;-a&#8217;) at that point.</p>
 
-<p>OK, now we&#8217;ve seen how to modify, stage and commit changes to files. Next we&#8217;ll look at one of the killer features of Git, it&#8217;s branching model.</p>
+<p>OK, now we&#8217;ve seen how to modify, stage and commit changes to files. Next we&#8217;ll look at one of the killer features of Git, its branching model.</p>
 
 <p>For more information on basic Git usage, you can read <a href='http://progit.org/book/ch2-0.html'>Chapter 2</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="setup.html">&laquo; previous</a></div><div style="text-align:right" class="span-11 last"><a href="branching.html">next &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
@@ -242,16 +242,15 @@ index c526f88..879f0d4 100644
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/p/remotes.html
+++ b/p/remotes.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1>Distributed Git</h1>
       <p>Fetch, merge, pull and push between multiple remote repositories.</p>
     </div>
-    
+
     <div class="content">
       <div class="span-21"><hr/><p>So you&#8217;ve heard that Git is a <strong>distributed</strong> version control system. What does that really mean and how do you take advantage of it?</p>
 
@@ -63,19 +63,16 @@ Receiving objects: 100% (85/85), 19.89 KiB, done.
 Resolving deltas: 100% (31/31), done.
 $ cd grack
 $ git remote
-origin
-$ git remote -v
-origin	git://github.com/schacon/grack.git (fetch)
-origin	git://github.com/schacon/grack.git (push)</code></pre>
+origin</code></pre>
 
 <p>If you created your repository with <code>git init</code> or would simply like to add another remote to a repository that you cloned, you can do so with the <code>git remote</code> command.</p>
 
 <pre><code>$ git remote add writey git@github.com:schacon/grack.git
-$ git remote -v
-origin	git://github.com/schacon/grack.git (fetch)
-origin	git://github.com/schacon/grack.git (push)
-writey	git@github.com:schacon/grack.git (fetch)
-writey	git@github.com:schacon/grack.git (push)</code></pre>
+$ git remote
+origin
+writey</code></pre>
+
+<h3 id='fetching_and_pulling'>fetching and pulling</h3>
 
 <p>The name of the alias doesn&#8217;t really matter - you can call it just about anything you want. Now you have an alias for that URL, so you can use it to push to or fetch from. For instance, in this case if someone pushed to the URL I cloned my project from originally and I wanted to get the updates, I can just run:</p>
 
@@ -95,16 +92,15 @@ writey	git@github.com:schacon/grack.git (push)</code></pre>
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/p/setup.html
+++ b/p/setup.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1>Setup and Initialization</h1>
       <p>Setup your Git environment, then create a new Git repository and clone an existing one.</p>
     </div>
-    
+
     <div class="content">
       <div class="span-21"><center><embed src="http://blip.tv/play/AeyWYQAI" type="application/x-shockwave-flash" width="790" height="444" allowscriptaccess="always" allowfullscreen="true"></embed></center><hr/><h3 id='setting_up_git'>setting up git</h3>
 
@@ -108,16 +108,15 @@ Rakefile       lib            spec</code></pre>
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/template/index.erb.html
+++ b/template/index.erb.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,7 +35,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-24" id="welcome">
       <h1>Welcome to the GitHub Learning site</h1>
       <p>Here you can learn why you should use version control, why you should switch to Git from SVN,<br/>
@@ -53,33 +53,32 @@
 		<a href="p/svn.html">Git vs Subversion</a>
       </div>
     </div>
-    
+
     <div class="span-8 last" id="hour">
       <div class="button blue">
-        <a href="p/hour.html">Git in 1 Hour Screencast</a>     
+        <a href="p/hour.html">Git in 1 Hour Screencast</a>
       </div>
     </div>
-    
+
     <div class="span-24 last">
       <br clear="both"/>
       <hr/>
     </div>
-    
+
     <%= @content %>
 
     <div id="footer" class="span-24">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">

--- a/template/page.erb.html
+++ b/template/page.erb.html
@@ -8,13 +8,13 @@
 	<script type="text/javascript" src="../js/jquery-1.2.6.pack.js"></script>
 	<script type="text/javascript" src="../js/thickbox-compressed.js"></script>
 	<script type="text/javascript" src="../js/jquery.corner.js"></script>
-	
+
 	<link rel="stylesheet" href="../css/screen.css" type="text/css" media="screen, projection">
   <link rel="stylesheet" href="../css/print.css" type="text/css" media="print">
   <!--[if IE]>
     <link rel="stylesheet" href="../css/ie.css" type="text/css" media="screen, projection">
   <![endif]-->
-  
+
 	<link rel="stylesheet" href="../css/style.css" type="text/css" media="screen" charset="utf-8"/>
   <link rel="stylesheet" href="../css/thickbox.css" type="text/css" media="screen"/>
 </head>
@@ -35,12 +35,12 @@
         </div>
       </div>
     </div>
-    
+
     <div class="span-21" id="welcome">
       <h1><%= @title %></h1>
       <p><%= @desc %></p>
     </div>
-    
+
     <div class="content">
       <%= @pcontent %>
     </div>
@@ -48,16 +48,15 @@
     <div id="footer" class="span-21">
       <div class="info span-12">
         <div class="links">
-          <a href="http://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
-          <a href="http://github.com/blog">Blog</a> |
-          <a href="http://support.github.com/">Support</a> |
-          <a href="http://github.com/training">Git Training</a> |
-          <a href="http://github.com/contact">Contact</a> |
-          <a href="http://groups.google.com/group/github/">Google Group</a> |
-          <a href="http://status.github.com">Status</a>
+          <a href="https://github.com/blog/148-github-shirts-now-available">T-Shirts</a> |
+          <a href="https://github.com/blog">Blog</a> |
+          <a href="https://github.com/contact">Contact &amp; Support </a> |
+          <a href="http://training.github.com/">Git Training</a> |
+          <a href="http://groups.google.com/group/github/">Google Groups</a> |
+          <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">
-          &copy; 2010 GitHub Inc. All rights reserved. | <a href="http://github.com/site/terms">Terms of Service</a> | <a href="http://github.com/site/privacy">Privacy Policy</a>
+          &copy; 2012 GitHub Inc. All rights reserved. | <a href="https://help.github.com/articles/github-terms-of-service">Terms of Service</a> | <a href="https://help.github.com/articles/github-privacy-policy">Privacy Policy</a>
         </div>
       </div>
       <div class="fork span-7">


### PR DESCRIPTION
Most of the footer links now redirect to a HTTPS version, including Status, cutting out the middle mong here.

Noticed also that the Support and Contact on the main GitHub site are in the one, so matching up the footer here to go with it.

Includes the generated files from rake, but honestly don't know what happened there to have diff say whole swathe done. Hoping it's just line ending conflicts since the content (that wasn't explicitly changed) appears to be the same (but then that shouldn't be an issue since that wasn't fidaddled by any manual edits).

Apologies if this site was supposed to be shelved (as mentioned by #3) and this is just kicking its armpit.
