### PR TITLE
Polish Amending to Markdown format

### DIFF
--- a/pages/amending.markdown
+++ b/pages/amending.markdown
@@ -1,136 +1,89 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+From time to time you may write a commit message that doesn't make sense,
+has a typo you want to fix or has left out some other information. Git
+allows you to modify commit messages.
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+### warning ###
 
-	<title>Changing Git History</title>
-	
-	<style type="text/css">
-		html { font-family: "helvetica"; color: #333; }
-		body {
-  		margin-top: 1.5em;
-    }
-    #container {
-      margin: 0 auto;
-      width: 800px;
-    }
-		h1 { font-size: 2.5em; color: #666; }
-		h2 { font-size: 1.5em; color: #111; }
-		pre { background-color: #eee; margin: 10px; padding: 15px;}
-		.hl { background: #ee8; }
-	</style>
-	
-</head>
+Refrain from editing commits that have already been pushed upstream to a 
+remote or central server. Like rebasing, amending commits is changing 
+history. Working alone, this is not a problem. If there are other people 
+on the project, amending pushed commit messages will mess things up.
 
-<body>
+### changing the last commit message ###
+
+If you want to modify your last commit message, run the following:
+
+	$ git commit --amend
+
+This will open up your text editor and allow you to change the last commit
+message.
+
+### changing multiple commit message ###
+
+There may be times where you want to edit multiple commit messages, or 
+to modify a commit message several commits back. In such cases, you need
+to use a tool called "interactive rebase". 
+
+You can run this with the `-i` flag option with `git rebase`. 
+You will need to specify how far back you want to rewrite commits by telling
+it which commit to go to.
+
+If you want to change the last three commit messages, or any of the commit 
+messages up to that point, add `HEAD~3` to the `git rebase -i` command.
+
+	$ git rebase -i HEAD~3
+
+Running the above command will give you a list of commits in your text editor
+that looks something like this:
+
+	pick dd56df4 so the reference updates
+	pick 36c7dba updated ticgit gem
+	pick 7482e0d updated the gemspec to hopefully work better
+
+	# Rebase b429ad8..7482e0d onto b429ad8
+	#
+	# Commands:
+	#  p, pick = use commit
+	#  e, edit = use commit, but stop for amending
+	#  s, squash = use commit, but meld into previous commit
+	#
+	# If you remove a line here THAT COMMIT WILL BE LOST.
+	# However, if you remove everything, the rebase will be aborted.
+	#
+
+Replace the word "pick" with "edit" for each of the commit messages you want to 
+change. For example, if you only want to change the third message
+we would edit the file like this:
+
+	pick dd56df4 so the reference updates
+	pick 36c7dba updated ticgit gem
+	edit 7482e0d updated the gemspec to hopefully work better
   
-  <div id="container">
+When you save and exit the editor, it will rewind you back to the last
+commit in that list and drop you on the command line with the following 
+message:
 
-    <h1>Changing Your Commit Messages</h1>
 
-    This document describes how to modify commit messages in Git after the fact.
+	$ git rebase -i HEAD~3
+	Stopped at 7482e0d... updated the gemspec to hopefully work better
+	You can amend the commit now, with
 
-    <h2>Changing the Last Commit Message</h2>
-    
-    <p>
-      If you only want to modify your last commit message, it is very simple.
-      Just run
-    </p>
-    
-    <pre>$ git commit --amend</pre>
-    
-    <p>
-      That will drop you into your text exitor and let you change the last
-      commit message.
-    </p>
+		git commit --amend
 
-    <h2>Changing Multiple Commit Messages</h2>
-    
-    <p>
-      Now let's assume that you want to modify either multiple commit messages,
-      or a commit message several commits back.  In this case, you need to use
-      a tool called 'interactive rebase'.  You can run this with the <em>-i</em>
-      option to <code>git rebase</code>.  You will need to supply how far back you 
-      want to rewrite commits by telling it which commit to go back to.
-    </p>
-    
-    <p>  
-      If you want to change the last 3 commit messages, or any of the commit 
-      messages up to that point, supply 'HEAD~3' to the <code>git rebase -i</code>
-      command.
-    </p>
-    
-    <pre>$ git rebase -i HEAD~3</pre>
-      
-    <div class="warning">Warning: every commit you see in this list will be 
-      re-written, whether you change the message or not.  Do not include any
-      commit you have already pushed to a central server - it will mess other 
-      people up.
-    </div>
-    
-    <p>
-      Running this command will give you a list of commits in your text editor
-      that looks something like this:
-    </p>
-    
-    <pre>pick dd56df4 so the reference updates
-pick 36c7dba updated ticgit gem
-pick 7482e0d updated the gemspec to hopefully work better
+	Once you are satisfied with your changes, run
 
-# Rebase b429ad8..7482e0d onto b429ad8
-#
-# Commands:
-#  p, pick = use commit
-#  e, edit = use commit, but stop for amending
-#  s, squash = use commit, but meld into previous commit
-#
-# If you remove a line here THAT COMMIT WILL BE LOST.
-# However, if you remove everything, the rebase will be aborted.
-#
-</pre>
+		git rebase --continue
 
-  <p>Change the word 'pick' to the work 'edit' for each of the commits you 
-    want to change the message for.  For example, let's say we want to change
-    the third commit message only, we would change the file to look like this
-  </p>
+These instructions tell you exactly what to do. Type the following:
+
+
+	$ git commit --amend
+ 
+Change the commit message and exit the editor. Then run:
+ 
+	$ git rebase --continue
   
-      <pre>pick dd56df4 so the reference updates
-pick 36c7dba updated ticgit gem
-<span class="hl">edit</span> 7482e0d updated the gemspec to hopefully work better</pre>
-  
-  <p>
-    When you save and exit the editor, it will rewind you back to that last
-    commit in that list and drop you on the command line with the following
-    message:
-  </p>
-  
-  <pre>$ git rebase -i HEAD~3
-Stopped at 7482e0d... updated the gemspec to hopefully work better
-You can amend the commit now, with
-
-	git commit --amend
-
-Once you are satisfied with your changes, run
-
-	git rebase --continue
-</pre>
-
-  <p>These instructions tell you exactly what to do.  Type</p>
-  
-  <pre>$ git commit --amend</pre>
-  
-  <p>Change the commit message and exit the editor.  Then run</p>
-  
-  <pre>$ git rebase --continue</pre>
-  
-  <p>
-    You can repeat those steps for each commit you changed to <code>edit</code>.
-    Each time it will stop and let you amend the commit and continue when you're 
-    done.  In this case, we had no other 'edit's so it will simply rebase the rest
-    of the commits and we're done!
-  </p>
-
-</body>
-</html>
+You can repeat these steps for each commit you changed to `edit`. Each time 
+it will stop and let you amend the commit and continue when you're done. In 
+this example, we had no other `edit`s so it will simply rebase the rest
+of the commits. And we're done!


### PR DESCRIPTION
Doesn't appear in the episodes list, so for your approval, a few line changes on the amending commits lesson with the following:
- warning should jump to top to let people know what dangers lay ahead should they want to step into the world of amending commit messages
- strip down and convert whole shake to markdown, gutting the html to be inline with rest of source pages
- used inline code backticks for commands mentioned in sentences as they could visually do to stand out more than when otherwise surrounded by quotes

Suggested possible episode listing:

```
name: Amending commit messages
desc: Edit one or more commit messages
```
