### PR TITLE
Show title of next/previous page for a better heads up

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,15 +39,15 @@ def generate_page(page_data)
   @pcontent += '</div>'
   
   @pcontent += "<div class=\"span-10\">"
-  if n = @nextlast[:last][page]
-    @pcontent += "<a href=\"#{n}.html\">&laquo; previous</a>"
+  if (n = @nextlast[:last][page]) && (nname = @nextlast[:lastname][page])
+    @pcontent += "<a href=\"#{n}.html\">&laquo; #{nname}</a>"
   else
     @pcontent += "&nbsp;"
   end
   @pcontent += "</div>"
 
-  if n = @nextlast[:next][page]
-    @pcontent += "<div style=\"text-align:right\" class=\"span-11 last\"><a href=\"#{n}.html\">next &raquo;</a></div>"
+  if (n = @nextlast[:next][page]) && (nname = @nextlast[:nextname][page])
+    @pcontent += "<div style=\"text-align:right\" class=\"span-11 last\"><a href=\"#{n}.html\">#{nname} &raquo;</a></div>"
   end
 
   @pcontent += '<div class="span-24 last">&nbsp;</div><hr/>'
@@ -65,14 +65,17 @@ task :gensite do
   @content = ''
 
   # finding the next and last pages
-  last = nil
-  @nextlast = {:last => {}, :next => {}}
+  last = lastname = nil
+  @nextlast = {:last => {}, :lastname => {}, :next => {}, :nextname => {}}
   ep['episodes'].each do |section|
     section['values'].each do |episode|
-      if p = episode['page']
+      if (p = episode['page']) && (pname = episode['name'])
         @nextlast[:last][p] = last
+        @nextlast[:lastname][p] = lastname
         @nextlast[:next][last] = p
+        @nextlast[:nextname][last] = pname
         last = p
+        lastname = pname
       end
     end
   end

--- a/p/branching.html
+++ b/p/branching.html
@@ -182,7 +182,7 @@ $ git commit
 
 <p>So, that is basic branching and merging in Git and should give you a good baseline for being able to effectively use this powerful and ultimately pretty simple tool.</p>
 
-<p>For more information on branching and merging in Git, you can read <a href='http://progit.org/book/ch3-0.html'>Chapter 3</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="normal.html">&laquo; previous</a></div><div style="text-align:right" class="span-11 last"><a href="remotes.html">next &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>For more information on branching and merging in Git, you can read <a href='http://progit.org/book/ch3-0.html'>Chapter 3</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="normal.html">&laquo; Normal Workflow</a></div><div style="text-align:right" class="span-11 last"><a href="remotes.html">Distributed Git &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/intro.html
+++ b/p/intro.html
@@ -150,7 +150,7 @@ sys	0m0.011s</code></pre>
 
 <h3 id='resources'>resources</h3>
 
-<p>For more information on Git, the homepage is at <a href='http://git-scm.com'>git-scm.com</a>. We will also be referring heavily to the CC-licenced <a href='http://progit.org'>Pro Git Book</a> for more information on each of these sections.</p><br/><br/><hr/></div><div class="span-10">&nbsp;</div><div style="text-align:right" class="span-11 last"><a href="setup.html">next &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>For more information on Git, the homepage is at <a href='http://git-scm.com'>git-scm.com</a>. We will also be referring heavily to the CC-licenced <a href='http://progit.org'>Pro Git Book</a> for more information on each of these sections.</p><br/><br/><hr/></div><div class="span-10">&nbsp;</div><div style="text-align:right" class="span-11 last"><a href="setup.html">Setup and Initialization &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/log.html
+++ b/p/log.html
@@ -380,7 +380,7 @@ cf9957875c3a27b6ae4593e1fa9d4dabbde68433 completion: Fix GIT_PS1_SHOWDIRTYSTA
 
 <pre><code>$ git log master.. --pretty=oneline</code></pre>
 
-<p>Very useful commands. We&#8217;ll explain why this works fully in a later section, but for now it&#8217;s useful to just remember that it does that.</p><br/><br/><hr/></div><div class="span-10"><a href="remotes.html">&laquo; previous</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>Very useful commands. We&#8217;ll explain why this works fully in a later section, but for now it&#8217;s useful to just remember that it does that.</p><br/><br/><hr/></div><div class="span-10"><a href="remotes.html">&laquo; Distributed Git</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/normal.html
+++ b/p/normal.html
@@ -238,7 +238,7 @@ index c526f88..879f0d4 100644
 
 <p>OK, now we&#8217;ve seen how to modify, stage and commit changes to files. Next we&#8217;ll look at one of the killer features of Git, its branching model.</p>
 
-<p>For more information on basic Git usage, you can read <a href='http://git-scm.com/book/en/Git-Basics'>Chapter 2</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="setup.html">&laquo; previous</a></div><div style="text-align:right" class="span-11 last"><a href="branching.html">next &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>For more information on basic Git usage, you can read <a href='http://git-scm.com/book/en/Git-Basics'>Chapter 2</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="setup.html">&laquo; Setup and Initialization</a></div><div style="text-align:right" class="span-11 last"><a href="branching.html">Branching and Merging &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/remotes.html
+++ b/p/remotes.html
@@ -102,7 +102,7 @@ writey git@github.com:schacon/grack.git (push)</code></pre>
 
 <pre><code>$ git push writey master</code></pre>
 
-<p>That pushes my <code>master</code> branch to the <code>writey</code> aliased server.</p><br/><br/><hr/></div><div class="span-10"><a href="branching.html">&laquo; previous</a></div><div style="text-align:right" class="span-11 last"><a href="log.html">next &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>That pushes my <code>master</code> branch to the <code>writey</code> aliased server.</p><br/><br/><hr/></div><div class="span-10"><a href="branching.html">&laquo; Branching and Merging</a></div><div style="text-align:right" class="span-11 last"><a href="log.html">Git History &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/setup.html
+++ b/p/setup.html
@@ -102,7 +102,7 @@ Rakefile       lib            spec</code></pre>
 
 <pre><code>$ git clone http://github.com/schacon/munger.git</code></pre>
 
-<p>This is only available if the server has enabled it - if you are hosting your repository on GitHub, both git:// and http:// access are enabled.</p><br/><br/><hr/></div><div class="span-10"><a href="intro.html">&laquo; previous</a></div><div style="text-align:right" class="span-11 last"><a href="normal.html">next &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>This is only available if the server has enabled it - if you are hosting your repository on GitHub, both git:// and http:// access are enabled.</p><br/><br/><hr/></div><div class="span-10"><a href="intro.html">&laquo; Introduction To Git</a></div><div style="text-align:right" class="span-11 last"><a href="normal.html">Normal Workflow &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">


### PR DESCRIPTION
In place of "next" and "previous" as paging navigation, the name of the page would be better to a clearer clue as to what you're going through in the lesson plans.

The arrows already give you the visual of the paging, but a page title gives you more context.
