### PR TITLE
Google Groups no longer supported, shut down May 2011

### DIFF
--- a/p/branching.html
+++ b/p/branching.html
@@ -192,7 +192,6 @@ $ git commit
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/p/intro.html
+++ b/p/intro.html
@@ -160,7 +160,6 @@ sys	0m0.011s</code></pre>
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/p/log.html
+++ b/p/log.html
@@ -390,7 +390,6 @@ cf9957875c3a27b6ae4593e1fa9d4dabbde68433 completion: Fix GIT_PS1_SHOWDIRTYSTA
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/p/normal.html
+++ b/p/normal.html
@@ -248,7 +248,6 @@ index c526f88..879f0d4 100644
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/p/remotes.html
+++ b/p/remotes.html
@@ -112,7 +112,6 @@ writey git@github.com:schacon/grack.git (push)</code></pre>
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/p/setup.html
+++ b/p/setup.html
@@ -112,7 +112,6 @@ Rakefile       lib            spec</code></pre>
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/template/index.erb.html
+++ b/template/index.erb.html
@@ -74,7 +74,6 @@
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">

--- a/template/page.erb.html
+++ b/template/page.erb.html
@@ -52,7 +52,6 @@
           <a href="https://github.com/blog">Blog</a> |
           <a href="https://github.com/contact">Contact &amp; Support </a> |
           <a href="http://training.github.com/">Git Training</a> |
-          <a href="http://groups.google.com/group/github/">Google Groups</a> |
           <a href="https://status.github.com">Status</a>
         </div>
         <div class="company">


### PR DESCRIPTION
Since shuttered back in May 2011, take it off the footer to not lead any into a ghost town.

The announcement: https://groups.google.com/forum/?fromgroups=#!topic/github/TbbbBkAm-jk
