### PR TITLE
Update progit.org links to git-scm.com

### DIFF
--- a/p/branching.html
+++ b/p/branching.html
@@ -182,7 +182,7 @@ $ git commit
 
 <p>So, that is basic branching and merging in Git and should give you a good baseline for being able to effectively use this powerful and ultimately pretty simple tool.</p>
 
-<p>For more information on branching and merging in Git, you can read <a href='http://progit.org/book/ch3-0.html'>Chapter 3</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="normal.html">&laquo; Normal Workflow</a></div><div style="text-align:right" class="span-11 last"><a href="remotes.html">Distributed Git &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>For more information on branching and merging in Git, you can read <a href='http://git-scm.com/book/en/Git-Branching'>Chapter 3</a> of the Pro Git book.</p><br/><br/><hr/></div><div class="span-10"><a href="normal.html">&laquo; Normal Workflow</a></div><div style="text-align:right" class="span-11 last"><a href="remotes.html">Distributed Git &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/intro.html
+++ b/p/intro.html
@@ -66,7 +66,7 @@ $ git help log</code></pre>
 
 <h3 id='open_source'>open source</h3>
 
-<p>Git is an open source project, that has been active for several years and is written mostly in C.</p>
+<p>Git is an open source project that has been active for several years and is written mostly in C.</p>
 
 <p><img alt='Git Language Breakdown' src='../images/git-lang.png' /></p>
 
@@ -146,11 +146,11 @@ sys	0m0.011s</code></pre>
 
 <h3 id='installing_git'>installing git</h3>
 
-<p>See the <a href='http://progit.org/book/ch1-4.html'>Pro Git Book</a> for details on how to install Git on your particular operating system. Or, simply go to the <a href='http://git-scm.com/download'>download</a> page on git-scm.com to get the source or an installer for your system.</p>
+<p>See the <a href='http://git-scm.com/book/en/Getting-Started-Installing-Git'>Pro Git book</a> for details on how to install Git on your particular operating system. Or, simply go to the <a href='http://git-scm.com/download'>download</a> page on git-scm.com to get the source or an installer for your system.</p>
 
 <h3 id='resources'>resources</h3>
 
-<p>For more information on Git, the homepage is at <a href='http://git-scm.com'>git-scm.com</a>. We will also be referring heavily to the CC-licenced <a href='http://progit.org'>Pro Git Book</a> for more information on each of these sections.</p><br/><br/><hr/></div><div class="span-10">&nbsp;</div><div style="text-align:right" class="span-11 last"><a href="setup.html">Setup and Initialization &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
+<p>For more information on Git, the homepage is at <a href='http://git-scm.com'>git-scm.com</a>. We will also be referring heavily to the Creative Commons licenced <a href='http://git-scm.com/book'>Pro Git book</a> for more information on each of these sections.</p><br/><br/><hr/></div><div class="span-10">&nbsp;</div><div style="text-align:right" class="span-11 last"><a href="setup.html">Setup and Initialization &raquo;</a></div><div class="span-24 last">&nbsp;</div><hr/>
     </div>
 
     <div id="footer" class="span-21">

--- a/p/log.html
+++ b/p/log.html
@@ -206,7 +206,7 @@ The title was &gt;&gt;commit the todo&lt;&lt;
 The author of 8a5cbc4 was Scott Chacon, 5 months ago
 The title was &gt;&gt;updated readme&lt;&lt;</code></pre>
 
-<p>See the <a href='http://www.kernel.org/pub/software/scm/git/docs/git-log.html'>git log docs</a> for all the different options you can put in that string.</p>
+<p>See the <a href='http://git-scm.com/docs/git-log'>git log docs</a> for all the different options you can put in that string.</p>
 
 <h4 id='branch_graph'>Branch Graph</h4>
 

--- a/pages/branching.markdown
+++ b/pages/branching.markdown
@@ -198,5 +198,5 @@ So, that is basic branching and merging in Git and should give you a good
 baseline for being able to effectively use this powerful and ultimately pretty
 simple tool.
 
-For more information on branching and merging in Git, you can read [Chapter 3](http://progit.org/book/ch3-0.html)
+For more information on branching and merging in Git, you can read [Chapter 3](http://git-scm.com/book/en/Git-Branching)
 of the Pro Git book.

--- a/pages/intro.markdown
+++ b/pages/intro.markdown
@@ -9,7 +9,7 @@ introduction before we start using it.
 Git is a **fast, open source, distributed version** control system that is quickly
 replacing subversion in open source and corporate programming communities.
 
-### version control system ###
+### version control system 
 
 First off, Git is a _version control system_, a simple command line
 tool for keeping a history on the state of your source code projects. You
@@ -37,7 +37,7 @@ show you the _man_ page. You can also type 'git help _command_' for the same thi
 
 ### open source
 
-Git is an open source project, that has been active for several years and is
+Git is an open source project that has been active for several years and is
 written mostly in C.
 
 ![Git Language Breakdown](../images/git-lang.png)
@@ -104,7 +104,7 @@ difference - one that severely changes your workflow.
 Most commands in Git seem instantaneous - no more typing 'svn commit' and
 then going for a cup of coffee.
 
-### small (vs svn) ###
+### small (vs svn) 
 
 Git is also very space efficient.  For example, if you import the Django project
 from SVN into Git and compare their checkout/clone sizes, Git comes out very
@@ -165,7 +165,7 @@ of Git.
 
 ### installing git
 
-See the [Pro Git Book](http://progit.org/book/ch1-4.html)
+See the [Pro Git book](http://git-scm.com/book/en/Getting-Started-Installing-Git)
 for details on how to install Git on your particular operating system.  Or,
 simply go to the [download](http://git-scm.com/download) page on git-scm.com to
 get the source or an installer for your system.
@@ -173,9 +173,6 @@ get the source or an installer for your system.
 ### resources
 
 For more information on Git, the homepage is at [git-scm.com](http://git-scm.com).
-We will also be referring heavily to the CC-licenced [Pro Git Book](http://progit.org)
-for more information on each of these sections.
-
-
-
+We will also be referring heavily to the Creative Commons licenced 
+[Pro Git book](http://git-scm.com/book) for more information on each of these sections.
 

--- a/pages/log.markdown
+++ b/pages/log.markdown
@@ -180,7 +180,7 @@ from, since you know the format won't change from one Git release to another.
 	The author of 8a5cbc4 was Scott Chacon, 5 months ago
 	The title was >>updated readme<<
 
-See the [git log docs](http://www.kernel.org/pub/software/scm/git/docs/git-log.html)
+See the [git log docs](http://git-scm.com/docs/git-log)
 for all the different options you can put in that string.
 
 #### Branch Graph ####


### PR DESCRIPTION
- Link to log man page also folded into one hosted on git-scm
- Expand "CC" into "Creative Commons" since it's the first time used
- Trimmed the Markdown ATX heading hashing to go with majority using the leading and not on both sides on same source page
