### PR TITLE
Add link to Introduction to Git from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 		<ul class="gears">
 			<li class="apple">
 				<ul>
-					<li><a href="#ComingSoon">Study</a></li>
+					<li><a href="p/intro.html">Introduction</a></li>
 					<li><a href="http://try.github.com">Try</a></li>
 					<li><a href="http://help.github.com">Help</a></li>
 				</ul>


### PR DESCRIPTION
Without it a user can't follow through from all the cogs that link elsewhere but within.

Swaps out the "Study" link which was holding at "ComingSoon" until it smiths out how soon is now. At least it looked like it could do with a spell on the bench for a bit.

Fixes #23
