### PR TITLE
Add link to YouTube channel that was replaced by screencasts page

### DIFF
--- a/js/gitcasts.js
+++ b/js/gitcasts.js
@@ -1,9 +1,8 @@
 $(function(){
-  $('.js-gitcasts a').click(function(){
+  $('.js-gitcasts li a').click(function(){
     var ep = $(this).attr('href')
     var epURL = ep.split('v=')
-    var embed = 'http://www.youtube.com/embed/'+epURL[1]+'?rel=0'
-    $('#js-youtubed').attr('src', embed)
+    $('#js-youtubed').attr('src', 'http://www.youtube.com/embed/'+epURL[1]+'?rel=0')
     scroll(0,0)
     return false
   })

--- a/pages/screencasts.md
+++ b/pages/screencasts.md
@@ -7,3 +7,5 @@
 - [Rebasing](http://www.youtube.com/watch?v=FyxiLdelSqc)
 - [Distributed Workflow](http://www.youtube.com/watch?v=KWNIKb6sftw)
 - [Creating Empty Branches](http://www.youtube.com/watch?v=vf8NVmLcqT8)
+
+ [Check out our YouTube channel](http://www.youtube.com/github) for more screencasts on Git and GitHub.

--- a/screencasts.html
+++ b/screencasts.html
@@ -39,7 +39,9 @@
 <li><a href='http://www.youtube.com/watch?v=KWNIKb6sftw'>Distributed Workflow</a></li>
 
 <li><a href='http://www.youtube.com/watch?v=vf8NVmLcqT8'>Creating Empty Branches</a></li>
-</ul></div><script src="../js/jquery-1.2.6.pack.js"></script><script src="../js/gitcasts.js"></script>
+</ul>
+
+<p><a href='http://www.youtube.com/github'>Check out our YouTube channel</a> for more screencasts on Git and GitHub.</p></div><script src="../js/jquery-1.2.6.pack.js"></script><script src="../js/gitcasts.js"></script>
   </div>
 </div>
 <div class="container">


### PR DESCRIPTION
The self-contained page of Git starter screencasts that brought in the links from gitcasts.com replaced the raw link to YouTube that was sitting on the homepage, so let's bring it back.

Also scopes the JavaScript to only pick out the links in the list and not the rest of the div block. Otherwise you're never getting out.
